### PR TITLE
feat: update dependencies and refactor tests to use 'package:test'

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,29 @@
-include: package:flutter_lints/flutter.yaml
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
 
-# Additional information about this file can be found at
+include: package:lints/recommended.yaml
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
 # https://dart.dev/guides/language/analysis-options

--- a/lib/legacy_bcs.dart
+++ b/lib/legacy_bcs.dart
@@ -8,7 +8,6 @@ import 'package:bcs/consts.dart';
 import 'package:bcs/reader.dart';
 import 'package:bcs/utils.dart';
 import 'package:bcs/writer.dart';
-import 'package:flutter/foundation.dart';
 
 const SUI_ADDRESS_LENGTH = 32;
 
@@ -26,12 +25,15 @@ mixin TypeInterface {
   BcsWriter encode(dynamic data, BcsWriterOptions? options, List<TypeName> typeParams);
   dynamic decode(Uint8List data, List<TypeName> typeParams);
 
-  BcsWriter encodeRaw(BcsWriter writer, dynamic data, List<TypeName> typeParams, Map<String, TypeName> typeMap);
+  BcsWriter encodeRaw(
+      BcsWriter writer, dynamic data, List<TypeName> typeParams, Map<String, TypeName> typeMap);
   dynamic decodeRaw(BcsReader reader, List<TypeName> typeParams, Map<String, TypeName> typeMap);
 }
 
-typedef BcsWriter EncodeCb(BcsWriter writer, dynamic data, List<TypeName> typeParams, Map<String, TypeName> typeMap);
-typedef dynamic DecodeCb(BcsReader reader, List<TypeName> typeParams, Map<String, TypeName> typeMap);
+typedef BcsWriter EncodeCb(
+    BcsWriter writer, dynamic data, List<TypeName> typeParams, Map<String, TypeName> typeMap);
+typedef dynamic DecodeCb(
+    BcsReader reader, List<TypeName> typeParams, Map<String, TypeName> typeMap);
 typedef bool ValidateCb(dynamic data);
 
 class TypeEncodeDecode with TypeInterface {
@@ -51,9 +53,9 @@ class TypeEncodeDecode with TypeInterface {
     }
 
     final bcsWriter = BcsWriter(
-      size: options?.size ?? 4096, 
-      maxSize: options?.maxSize, 
-      allocateSize: options?.allocateSize ?? 1024);
+        size: options?.size ?? 4096,
+        maxSize: options?.maxSize,
+        allocateSize: options?.allocateSize ?? 1024);
     return encodeRaw(bcsWriter, data, typeParams, typeMap);
   }
 
@@ -82,7 +84,6 @@ class TypeEncodeDecode with TypeInterface {
   dynamic decodeRaw(reader, typeParams, typeMap) {
     return decodeCb(reader, typeParams, typeMap);
   }
-
 }
 
 /// Struct type definition. Used as input format in BcsConfig.types
@@ -140,15 +141,14 @@ class BcsConfig {
   /// Whether to auto-register primitive types on launch.
   bool? withPrimitives;
 
-  BcsConfig({
-    required this.vectorType,
-    required this.addressLength,
-    this.fixedArrayType,
-    this.addressEncoding,
-    this.genericSeparators,
-    this.types,
-    this.withPrimitives
-  });
+  BcsConfig(
+      {required this.vectorType,
+      required this.addressLength,
+      this.fixedArrayType,
+      this.addressEncoding,
+      this.genericSeparators,
+      this.types,
+      this.withPrimitives});
 }
 
 /// BCS implementation for Move types and few additional built-ins.
@@ -203,10 +203,7 @@ class LegacyBCS {
 
     // Register address type under key 'address'.
     registerAddressType(
-      LegacyBCS.ADDRESS,
-      schema.addressLength,
-      schema.addressEncoding ?? Encoding.hex
-    );
+        LegacyBCS.ADDRESS, schema.addressLength, schema.addressEncoding ?? Encoding.hex);
     registerVectorType(schema.vectorType);
 
     if (schema.fixedArrayType != null) {
@@ -243,25 +240,17 @@ class LegacyBCS {
   ///
   /// ```dart
   /// bcs.registerVectorType('vector<u8>');
-  /// 
+  ///
   /// final serialized = bcs
   ///   .ser('vector<u8>', [1,2,3,4,5,6])
   ///   .toBytes();
-  /// 
+  ///
   /// expect(toHEX(serialized), '06010203040506');
   /// ```
-  BcsWriter ser(
-    dynamic type,
-    dynamic data,
-    [BcsWriterOptions? options]
-  ) {
+  BcsWriter ser(dynamic type, dynamic data, [BcsWriterOptions? options]) {
     if (type is String || type is Iterable) {
       final (name, params) = parseTypeName(type);
-      return getTypeInterface(name).encode(
-        data,
-        options,
-        params
-      );
+      return getTypeInterface(name).encode(data, options, params);
     }
 
     // Quick serialization without registering the type in the main struct.
@@ -271,9 +260,7 @@ class LegacyBCS {
       return temp.registerStructType(key, type).ser(key, data, options);
     }
 
-    throw ArgumentError(
-      "Incorrect type passed into the '.ser()' function. \n${jsonEncode(type)}"
-    );
+    throw ArgumentError("Incorrect type passed into the '.ser()' function. \n${jsonEncode(type)}");
   }
 
   /// Deserialize BCS into a Dart type.
@@ -282,11 +269,7 @@ class LegacyBCS {
   /// final deNum = bcs.de('u64', num, Encoding.hex);
   /// expect(deNum.toString(), '4294967295');
   ///```
-  dynamic de(
-    dynamic type,
-    dynamic data,
-    [Encoding? encoding]
-  ) {
+  dynamic de(dynamic type, dynamic data, [Encoding? encoding]) {
     if (data is String) {
       if (encoding != null) {
         data = decodeStr(data, encoding);
@@ -308,9 +291,7 @@ class LegacyBCS {
       return temp.registerStructType(key, type).de(key, data, encoding);
     }
 
-    throw ArgumentError(
-      "Incorrect type passed into the '.de()' function. \n${jsonDecode(type)}"
-    );
+    throw ArgumentError("Incorrect type passed into the '.de()' function. \n${jsonDecode(type)}");
   }
 
   /// Check whether a `TypeInterface` has been loaded for a `type`.
@@ -347,12 +328,8 @@ class LegacyBCS {
   /// );
   /// expect(bcs.ser('number_string', '12345').toBytes(), [5,1,2,3,4,5]);
   /// ```
-  LegacyBCS registerType(
-    TypeName typeName,
-    EncodeCb encodeCb,
-    DecodeCb decodeCb,
-    [ValidateCb? validateCb]
-  ) {
+  LegacyBCS registerType(TypeName typeName, EncodeCb encodeCb, DecodeCb decodeCb,
+      [ValidateCb? validateCb]) {
     validateCb ??= (data) => true;
 
     final (name, generics) = parseTypeName(typeName);
@@ -367,31 +344,18 @@ class LegacyBCS {
   /// bcs.registerAddressType('address', SUI_ADDRESS_LENGTH);
   /// final addr = bcs.de('address', 'c3aca510c785c7094ac99aeaa1e69d493122444df50bb8a99dfa790c654a79af', Encoding.hex);
   /// ```
-  LegacyBCS registerAddressType(
-    String name,
-    int length,
-    [Encoding encoding = Encoding.hex]
-  ) {
-
+  LegacyBCS registerAddressType(String name, int length, [Encoding encoding = Encoding.hex]) {
     switch (encoding) {
       case Encoding.base64:
-        return registerType(
-          name,
-          (writer, data, _, __) { 
-            fromB64(data).forEach((el) => writer.write8(el));
-            return writer;
-          },
-          (reader, _, __) => toB64(reader.readBytes(length))
-        );
+        return registerType(name, (writer, data, _, __) {
+          fromB64(data).forEach((el) => writer.write8(el));
+          return writer;
+        }, (reader, _, __) => toB64(reader.readBytes(length)));
       case Encoding.hex:
-        return registerType(
-          name,
-          (writer, data, _, __) { 
-            fromHEX(data).forEach((el) => writer.write8(el));
-            return writer;
-          },
-          (reader, _, __) => toHEX(reader.readBytes(length))
-        );
+        return registerType(name, (writer, data, _, __) {
+          fromHEX(data).forEach((el) => writer.write8(el));
+          return writer;
+        }, (reader, _, __) => toHEX(reader.readBytes(length)));
       default:
         throw ArgumentError("Unsupported encoding! Use either hex or base64");
     }
@@ -410,80 +374,48 @@ class LegacyBCS {
       throw ArgumentError("Vector can have only one type parameter; got " + name);
     }
 
-    return registerType(
-      typeName,
-      (writer, data, typeParams, typeMap) {
-        return writer.writeVec(data, (writer, el, _, __) {
-          if (typeParams.isEmpty) {
-            throw ArgumentError(
-              "Incorrect number of type parameters passed a to vector '$typeName'"
-            );
-          }
+    return registerType(typeName, (writer, data, typeParams, typeMap) {
+      return writer.writeVec(data, (writer, el, _, __) {
+        if (typeParams.isEmpty) {
+          throw ArgumentError("Incorrect number of type parameters passed a to vector '$typeName'");
+        }
 
-          final elementType = typeParams[0];
-          final (name, params) = parseTypeName(elementType);
-          if (hasType(name)) {
-            return getTypeInterface(name).encodeRaw(
-              writer,
-              el,
-              params,
-              typeMap
-            );
-          }
+        final elementType = typeParams[0];
+        final (name, params) = parseTypeName(elementType);
+        if (hasType(name)) {
+          return getTypeInterface(name).encodeRaw(writer, el, params, typeMap);
+        }
 
-          if (!(typeMap.containsKey(name))) {
-            throw ArgumentError(
-              "Unable to find a matching type definition for $name in vector; make sure you passed a generic"
-            );
-          }
+        if (!(typeMap.containsKey(name))) {
+          throw ArgumentError(
+              "Unable to find a matching type definition for $name in vector; make sure you passed a generic");
+        }
 
-          final (innerName, innerParams) = parseTypeName(
-            typeMap[name]
-          );
+        final (innerName, innerParams) = parseTypeName(typeMap[name]);
 
-          return getTypeInterface(innerName).encodeRaw(
-            writer,
-            el,
-            innerParams,
-            typeMap
-          );
-        });
-      },
-      (reader, typeParams, typeMap) { 
-        return reader.readVec((reader, _, __) {
-          if (typeParams.isEmpty) {
-            throw ArgumentError(
-              "Incorrect number of type parameters passed to a vector '$typeName'"
-            );
-          }
+        return getTypeInterface(innerName).encodeRaw(writer, el, innerParams, typeMap);
+      });
+    }, (reader, typeParams, typeMap) {
+      return reader.readVec((reader, _, __) {
+        if (typeParams.isEmpty) {
+          throw ArgumentError("Incorrect number of type parameters passed to a vector '$typeName'");
+        }
 
-          final elementType = typeParams[0];
-          final (name, params) = parseTypeName(elementType);
-          if (hasType(name)) {
-            return getTypeInterface(name).decodeRaw(
-              reader,
-              params,
-              typeMap
-            );
-          }
+        final elementType = typeParams[0];
+        final (name, params) = parseTypeName(elementType);
+        if (hasType(name)) {
+          return getTypeInterface(name).decodeRaw(reader, params, typeMap);
+        }
 
-          if (!(typeMap.containsKey(name))) {
-            throw ArgumentError(
-              "Unable to find a matching type definition for $name in vector; make sure you passed a generic"
-            );
-          }
+        if (!(typeMap.containsKey(name))) {
+          throw ArgumentError(
+              "Unable to find a matching type definition for $name in vector; make sure you passed a generic");
+        }
 
-          final (innerName, innerParams) = parseTypeName(
-            typeMap[name]
-          );
-          getTypeInterface(innerName).decodeRaw(
-            reader,
-            innerParams,
-            typeMap
-          );
-        });
-      }
-    );
+        final (innerName, innerParams) = parseTypeName(typeMap[name]);
+        getTypeInterface(innerName).decodeRaw(reader, innerParams, typeMap);
+      });
+    });
   }
 
   /// Register custom fixed array type inside the bcs.
@@ -499,82 +431,50 @@ class LegacyBCS {
       throw ArgumentError("Vector can have only one type parameter; got " + name);
     }
 
-    return registerType(
-      typeName,
-      (writer, data, typeParams, typeMap) {
-        int? size = typeParams.length > 1 ? int.parse(typeParams[1].toString()) : null;
-        return writer.writeFixedArray(data, size, (writer, el, _, __) {
-          if (typeParams.isEmpty) {
-            throw ArgumentError(
-              "Incorrect number of type parameters passed a to vector '$typeName'"
-            );
-          }
+    return registerType(typeName, (writer, data, typeParams, typeMap) {
+      int? size = typeParams.length > 1 ? int.parse(typeParams[1].toString()) : null;
+      return writer.writeFixedArray(data, size, (writer, el, _, __) {
+        if (typeParams.isEmpty) {
+          throw ArgumentError("Incorrect number of type parameters passed a to vector '$typeName'");
+        }
 
-          final elementType = typeParams[0];
-          final (name, params) = parseTypeName(elementType);
-          if (hasType(name)) {
-            return getTypeInterface(name).encodeRaw(
-              writer,
-              el,
-              params,
-              typeMap
-            );
-          }
+        final elementType = typeParams[0];
+        final (name, params) = parseTypeName(elementType);
+        if (hasType(name)) {
+          return getTypeInterface(name).encodeRaw(writer, el, params, typeMap);
+        }
 
-          if (!(typeMap.containsKey(name))) {
-            throw ArgumentError(
-              "Unable to find a matching type definition for $name in vector; make sure you passed a generic"
-            );
-          }
+        if (!(typeMap.containsKey(name))) {
+          throw ArgumentError(
+              "Unable to find a matching type definition for $name in vector; make sure you passed a generic");
+        }
 
-          final (innerName, innerParams) = parseTypeName(
-            typeMap[name]
-          );
+        final (innerName, innerParams) = parseTypeName(typeMap[name]);
 
-          return getTypeInterface(innerName).encodeRaw(
-            writer,
-            el,
-            innerParams,
-            typeMap
-          );
-        });
-      },
-      (reader, typeParams, typeMap) { 
-        final size = int.parse(typeParams[1].toString());
-        return reader.readFixedArray(size, (reader, _, __) {
-          if (typeParams.isEmpty) {
-            throw ArgumentError(
-              "Incorrect number of type parameters passed to a vector '$typeName'"
-            );
-          }
+        return getTypeInterface(innerName).encodeRaw(writer, el, innerParams, typeMap);
+      });
+    }, (reader, typeParams, typeMap) {
+      final size = int.parse(typeParams[1].toString());
+      return reader.readFixedArray(size, (reader, _, __) {
+        if (typeParams.isEmpty) {
+          throw ArgumentError("Incorrect number of type parameters passed to a vector '$typeName'");
+        }
 
-          final elementType = typeParams[0];
-          final (name, params) = parseTypeName(elementType);
-          if (hasType(name)) {
-            return getTypeInterface(name).decodeRaw(
-              reader,
-              params,
-              typeMap
-            );
-          }
+        final elementType = typeParams[0];
+        final (name, params) = parseTypeName(elementType);
+        if (hasType(name)) {
+          return getTypeInterface(name).decodeRaw(reader, params, typeMap);
+        }
 
-          if (!(typeMap.containsKey(name))) {
-            throw ArgumentError(
-              "Unable to find a matching type definition for $name in vector; make sure you passed a generic"
-            );
-          }
+        if (!(typeMap.containsKey(name))) {
+          throw ArgumentError(
+              "Unable to find a matching type definition for $name in vector; make sure you passed a generic");
+        }
 
-          final (innerName, innerParams) = parseTypeName(
-            typeMap[name]
-          );
-          getTypeInterface(innerName).decodeRaw(
-            reader,
-            innerParams,
-            typeMap
-          );
-        });
-      }
-    );
+        final (innerName, innerParams) = parseTypeName(typeMap[name]);
+        getTypeInterface(innerName).decodeRaw(reader, innerParams, typeMap);
+      });
+    });
   }
 
   /// Safe method to register a custom Move struct. The first argument is a name of the
@@ -616,10 +516,7 @@ class LegacyBCS {
   ///
   /// expect(test_set.toBytes(), rust_bcs_str);
   /// ```
-  LegacyBCS registerStructType(
-    TypeName typeName,
-    StructTypeDefinition fields
-  ) {
+  LegacyBCS registerStructType(TypeName typeName, StructTypeDefinition fields) {
     // When an Object is passed, we register it under a new key and store it
     // in the registered type system. This way we allow nested inline definitions.
     final fieldsTmp = <String, dynamic>{}; // fix dynamic change value type of Map
@@ -651,136 +548,91 @@ class LegacyBCS {
 
     // Make sure all the types in the fields description are already known
     // and that all the field types are strings.
-    return registerType(
-      typeName,
-      (writer, data, typeParams, typeMap) {
-        if (data == null) {
-          throw ArgumentError(
-            "Expected $structName to be an Object, got: $data"
-          );
-        }
-
-        if (typeParams.length != generics.length) {
-          throw ArgumentError(
-            "Incorrect number of generic parameters passed; expected: ${generics.length}, got: ${typeParams.length}"
-          );
-        }
-
-        if (data is! Map) {
-          data = data.toJson();
-        }
-
-        // follow the canonical order when serializing
-        for (String key in canonicalOrder) {
-          if (!data.containsKey(key)) {
-            throw Exception('Struct $structName requires field $key:${data[key]}');
-          }
-
-          // Before deserializing, read the canonical field type.
-          final (fieldType, fieldParams) = parseTypeName(
-            struct[key] as TypeName
-          );
-
-          // Check whether this type is a generic defined in this struct.
-          // If it is -> read the type parameter matching its index.
-          // If not - tread as a regular field.
-          if (!generics.contains(fieldType)) {
-            getTypeInterface(fieldType).encodeRaw(
-              writer,
-              data[key],
-              fieldParams,
-              typeMap
-            );
-          } else {
-            final paramIdx = generics.indexOf(fieldType);
-            final (name, params) = parseTypeName(typeParams[paramIdx]);
-
-            // If the type from the type parameters already exists
-            // and known -> proceed with type decoding.
-            if (hasType(name)) {
-              getTypeInterface(name).encodeRaw(
-                writer,
-                data[key],
-                params,
-                typeMap
-              );
-              continue;
-            }
-
-            // Alternatively, if it's a global generic parameter...
-            if (!(typeMap.containsKey(name))) {
-              throw ArgumentError(
-                "Unable to find a matching type definition for ${name} in ${structName}; make sure you passed a generic"
-              );
-            }
-
-            final (innerName, innerParams) = parseTypeName(
-              typeMap[name]
-            );
-            getTypeInterface(innerName).encodeRaw(
-              writer,
-              data[key],
-              innerParams,
-              typeMap
-            );
-          }
-        }
-        return writer;
-      },
-      (reader, typeParams, typeMap) {
-        if (typeParams.length != generics.length) {
-          throw ArgumentError(
-            "Incorrect number of generic parameters passed; expected: ${generics.length}, got: ${typeParams.length}"
-          );
-        }
-
-        final result = <String, dynamic>{};
-        for (String key in canonicalOrder) {
-          final(fieldName, fieldParams) = parseTypeName(
-            struct[key] as TypeName
-          );
-
-          // if it's not a generic
-          if (!generics.contains(fieldName)) {
-            result[key] = getTypeInterface(fieldName).decodeRaw(
-              reader,
-              fieldParams,
-              typeMap
-            );
-          } else {
-            final paramIdx = generics.indexOf(fieldName);
-            final (name, params) = parseTypeName(typeParams[paramIdx]);
-
-            // If the type from the type parameters already exists
-            // and known -> proceed with type decoding.
-            if (hasType(name)) {
-              result[key] = getTypeInterface(name).decodeRaw(
-                reader,
-                params,
-                typeMap
-              );
-              continue;
-            }
-
-            if (!(typeMap.containsKey(name))) {
-              throw ArgumentError(
-                "Unable to find a matching type definition for ${name} in ${structName}; make sure you passed a generic"
-              );
-            }
-
-            final (innerName, innerParams) = parseTypeName(
-              typeMap[name]
-            );
-            result[key] = getTypeInterface(innerName).decodeRaw.call(
-              reader,
-              innerParams,
-              typeMap
-            );
-          }
-        }
-        return result;
+    return registerType(typeName, (writer, data, typeParams, typeMap) {
+      if (data == null) {
+        throw ArgumentError("Expected $structName to be an Object, got: $data");
       }
-    );
+
+      if (typeParams.length != generics.length) {
+        throw ArgumentError(
+            "Incorrect number of generic parameters passed; expected: ${generics.length}, got: ${typeParams.length}");
+      }
+
+      if (data is! Map) {
+        data = data.toJson();
+      }
+
+      // follow the canonical order when serializing
+      for (String key in canonicalOrder) {
+        if (!data.containsKey(key)) {
+          throw Exception('Struct $structName requires field $key:${data[key]}');
+        }
+
+        // Before deserializing, read the canonical field type.
+        final (fieldType, fieldParams) = parseTypeName(struct[key] as TypeName);
+
+        // Check whether this type is a generic defined in this struct.
+        // If it is -> read the type parameter matching its index.
+        // If not - tread as a regular field.
+        if (!generics.contains(fieldType)) {
+          getTypeInterface(fieldType).encodeRaw(writer, data[key], fieldParams, typeMap);
+        } else {
+          final paramIdx = generics.indexOf(fieldType);
+          final (name, params) = parseTypeName(typeParams[paramIdx]);
+
+          // If the type from the type parameters already exists
+          // and known -> proceed with type decoding.
+          if (hasType(name)) {
+            getTypeInterface(name).encodeRaw(writer, data[key], params, typeMap);
+            continue;
+          }
+
+          // Alternatively, if it's a global generic parameter...
+          if (!(typeMap.containsKey(name))) {
+            throw ArgumentError(
+                "Unable to find a matching type definition for ${name} in ${structName}; make sure you passed a generic");
+          }
+
+          final (innerName, innerParams) = parseTypeName(typeMap[name]);
+          getTypeInterface(innerName).encodeRaw(writer, data[key], innerParams, typeMap);
+        }
+      }
+      return writer;
+    }, (reader, typeParams, typeMap) {
+      if (typeParams.length != generics.length) {
+        throw ArgumentError(
+            "Incorrect number of generic parameters passed; expected: ${generics.length}, got: ${typeParams.length}");
+      }
+
+      final result = <String, dynamic>{};
+      for (String key in canonicalOrder) {
+        final (fieldName, fieldParams) = parseTypeName(struct[key] as TypeName);
+
+        // if it's not a generic
+        if (!generics.contains(fieldName)) {
+          result[key] = getTypeInterface(fieldName).decodeRaw(reader, fieldParams, typeMap);
+        } else {
+          final paramIdx = generics.indexOf(fieldName);
+          final (name, params) = parseTypeName(typeParams[paramIdx]);
+
+          // If the type from the type parameters already exists
+          // and known -> proceed with type decoding.
+          if (hasType(name)) {
+            result[key] = getTypeInterface(name).decodeRaw(reader, params, typeMap);
+            continue;
+          }
+
+          if (!(typeMap.containsKey(name))) {
+            throw ArgumentError(
+                "Unable to find a matching type definition for ${name} in ${structName}; make sure you passed a generic");
+          }
+
+          final (innerName, innerParams) = parseTypeName(typeMap[name]);
+          result[key] = getTypeInterface(innerName).decodeRaw.call(reader, innerParams, typeMap);
+        }
+      }
+      return result;
+    });
   }
 
   /// Safe method to register custom enum type where each invariant holds the value of another type.
@@ -799,25 +651,17 @@ class LegacyBCS {
   /// bcs.ser('MyEnum', { 'single': { 'value': 10000000 } }).toBytes();
   /// bcs.ser('MyEnum', { 'multi': [ { 'value': 1 }, { 'value': 2 } ] });
   /// ```
-  LegacyBCS registerEnumType(
-    TypeName typeName,
-    EnumTypeDefinition variants
-  ) {
+  LegacyBCS registerEnumType(TypeName typeName, EnumTypeDefinition variants) {
     // When an Object is passed, we register it under a new key and store it
     // in the registered type system. This way we allow nested inline definitions.
     for (final key in variants.keys) {
       final internalName = tempKey();
       final value = variants[key];
 
-      if (
-        value != null &&
-        (value is! Iterable) &&
-        value is! String
-      ) {
+      if (value != null && (value is! Iterable) && value is! String) {
         variants[key] = internalName;
         registerStructType(internalName, value as StructTypeDefinition);
       }
-
     }
 
     // Make sure the order doesn't get changed
@@ -829,94 +673,68 @@ class LegacyBCS {
     // Parse type parameters in advance to know the index of each generic parameter.
     final (name, canonicalTypeParams) = parseTypeName(typeName);
 
-    return registerType(
-      typeName,
-      (writer, data, typeParams, typeMap) {
-        if (data == null) {
-          throw ArgumentError(
-            'Unable to write enum "$name", missing data.\nReceived: "$data'
-          );
-        }
-        if (data is! Map) {
-          throw ArgumentError(
-            'Incorrect data passed into enum "$name", expected object with properties: "${canonicalOrder.join(
-              " | "
-            )}".\nReceived: "${jsonEncode(data)}"'
-          );
-        }
-        
-        if (data.isEmpty) {
-          throw ArgumentError(
-            'Empty object passed as invariant of the enum "$name"'
-          );
-        }
-
-        final key = data.keys.first;
-        final orderByte = canonicalOrder.toList().indexOf(key);
-        if (orderByte == -1) {
-          throw ArgumentError(
-            'Unknown invariant of the enum "$name", allowed values: "${canonicalOrder.join(
-              " | "
-            )}"; received "$key"'
-          );
-        }
-        final invariant = canonicalOrder.toList()[orderByte];
-        final invariantType = struct[invariant];
-
-        // write order byte
-        writer.write8(orderByte);
-
-        // When { "key": null } - empty value for the invariant.
-        if (invariantType == null) {
-          return writer;
-        }
-
-        final paramIndex = canonicalTypeParams.indexOf(invariantType);
-        final typeOrParam =
-          paramIndex == -1 ? invariantType : typeParams[paramIndex];
-
-        {
-          final (name, params) = parseTypeName(typeOrParam);
-          return getTypeInterface(name).encodeRaw(
-            writer,
-            data[key],
-            params,
-            typeMap
-          );
-        }
-      },
-      (reader, typeParams, typeMap) {
-        final orderByte = reader.readULEB();
-        final invariant = canonicalOrder.toList()[orderByte];
-        final invariantType = struct[invariant];
-
-        if (orderByte == -1) {
-          throw ArgumentError(
-            'Decoding type mismatch, expected enum "$name" invariant index, received "$orderByte"'
-          );
-        }
-
-        // Encode an empty value for the enum.
-        if (invariantType == null) {
-          return { invariant: true };
-        }
-
-        final paramIndex = canonicalTypeParams.indexOf(invariantType);
-        final typeOrParam =
-          paramIndex == -1 ? invariantType : typeParams[paramIndex];
-
-        {
-          final (name, params) = parseTypeName(typeOrParam);
-          return {
-            invariant: getTypeInterface(name).decodeRaw(
-              reader,
-              params,
-              typeMap
-            ),
-          };
-        }
+    return registerType(typeName, (writer, data, typeParams, typeMap) {
+      if (data == null) {
+        throw ArgumentError('Unable to write enum "$name", missing data.\nReceived: "$data');
       }
-    );
+      if (data is! Map) {
+        throw ArgumentError(
+            'Incorrect data passed into enum "$name", expected object with properties: "${canonicalOrder.join(" | ")}".\nReceived: "${jsonEncode(data)}"');
+      }
+
+      if (data.isEmpty) {
+        throw ArgumentError('Empty object passed as invariant of the enum "$name"');
+      }
+
+      final key = data.keys.first;
+      final orderByte = canonicalOrder.toList().indexOf(key);
+      if (orderByte == -1) {
+        throw ArgumentError(
+            'Unknown invariant of the enum "$name", allowed values: "${canonicalOrder.join(" | ")}"; received "$key"');
+      }
+      final invariant = canonicalOrder.toList()[orderByte];
+      final invariantType = struct[invariant];
+
+      // write order byte
+      writer.write8(orderByte);
+
+      // When { "key": null } - empty value for the invariant.
+      if (invariantType == null) {
+        return writer;
+      }
+
+      final paramIndex = canonicalTypeParams.indexOf(invariantType);
+      final typeOrParam = paramIndex == -1 ? invariantType : typeParams[paramIndex];
+
+      {
+        final (name, params) = parseTypeName(typeOrParam);
+        return getTypeInterface(name).encodeRaw(writer, data[key], params, typeMap);
+      }
+    }, (reader, typeParams, typeMap) {
+      final orderByte = reader.readULEB();
+      final invariant = canonicalOrder.toList()[orderByte];
+      final invariantType = struct[invariant];
+
+      if (orderByte == -1) {
+        throw ArgumentError(
+            'Decoding type mismatch, expected enum "$name" invariant index, received "$orderByte"');
+      }
+
+      // Encode an empty value for the enum.
+      if (invariantType == null) {
+        return {invariant: true};
+      }
+
+      final paramIndex = canonicalTypeParams.indexOf(invariantType);
+      final typeOrParam = paramIndex == -1 ? invariantType : typeParams[paramIndex];
+
+      {
+        final (name, params) = parseTypeName(typeOrParam);
+        return {
+          invariant: getTypeInterface(name).decodeRaw(reader, params, typeMap),
+        };
+      }
+    });
   }
 
   /// Get a set of encoders/decoders for specific type.
@@ -931,10 +749,7 @@ class LegacyBCS {
       while (typeInterface is String) {
         if (chain.contains(typeInterface)) {
           throw ArgumentError(
-            'Recursive definition found: ${chain.join(
-              " -> "
-            )} -> $typeInterface'
-          );
+              'Recursive definition found: ${chain.join(" -> ")} -> $typeInterface');
         }
         chain.add(typeInterface);
         typeInterface = types[typeInterface];
@@ -981,16 +796,14 @@ class LegacyBCS {
 
     final typeName = name.substring(0, l_bound);
     final params = name
-      .substring(l_bound + 1, name.length - r_bound - 1)
-      .split(",")
-      .map((e) => e.trim())
-      .toList();
+        .substring(l_bound + 1, name.length - r_bound - 1)
+        .split(",")
+        .map((e) => e.trim())
+        .toList();
 
     return (typeName, params);
   }
 }
-
-
 
 /// Unify argument types by converting them to BigInt.
 BigInt toBN(dynamic number) {
@@ -1009,149 +822,93 @@ BigInt toBN(dynamic number) {
 /// Is called in the `BCS` constructor automatically but can
 /// be ignored if the `withPrimitives` argument is not set.
 void registerPrimitives(LegacyBCS bcs) {
-  bcs.registerType(
-    LegacyBCS.U8,
-    (writer, data, _, __) {
-      return writer.write8(int.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read8();
-    },
-    (u8) => toBN(u8) <= BigInt.from(MAX_U8_NUMBER)
-  );
+  bcs.registerType(LegacyBCS.U8, (writer, data, _, __) {
+    return writer.write8(int.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read8();
+  }, (u8) => toBN(u8) <= BigInt.from(MAX_U8_NUMBER));
+
+  bcs.registerType(LegacyBCS.U16, (writer, data, _, __) {
+    return writer.write16(int.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read16();
+  }, (u16) => toBN(u16) <= BigInt.from(MAX_U16_NUMBER));
+
+  bcs.registerType(LegacyBCS.U32, (writer, data, _, __) {
+    return writer.write32(int.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read32();
+  }, (u32) => toBN(u32) <= BigInt.from(MAX_U32_NUMBER));
+
+  bcs.registerType(LegacyBCS.U64, (writer, data, _, __) {
+    return writer.write64(BigInt.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read64().toString();
+  });
+
+  bcs.registerType(LegacyBCS.U128, (writer, data, _, __) {
+    return writer.write128(BigInt.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read128().toString();
+  });
+
+  bcs.registerType(LegacyBCS.U256, (writer, data, _, __) {
+    return writer.write256(BigInt.parse(data.toString()));
+  }, (reader, _, __) {
+    return reader.read256().toString();
+  });
+
+  bcs.registerType(LegacyBCS.BOOL, (writer, data, _, __) {
+    return writer.write8(data == true ? 1 : 0);
+  }, (reader, _, __) {
+    return reader.read8().toString() == "1";
+  });
 
   bcs.registerType(
-    LegacyBCS.U16,
-    (writer, data, _, __) {
-      return writer.write16(int.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read16();
-    },
-    (u16) => toBN(u16) <= BigInt.from(MAX_U16_NUMBER)
-  );
+      LegacyBCS.STRING,
+      (writer, data, _, __) => writer.writeVec(data.split(""), (writer, el, a, b) {
+            writer.write8(utf8.encode(el)[0]);
+          }), (reader, _, __) {
+    final data =
+        reader.readVec((reader, a, b) => reader.read8()).map<int>((item) => item.toInt()).toList();
+    return utf8.decode(data);
+  }, (_str) => true);
 
-  bcs.registerType(
-    LegacyBCS.U32,
-    (writer, data, _, __) {
-      return writer.write32(int.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read32();
-    },
-    (u32) => toBN(u32) <= BigInt.from(MAX_U32_NUMBER)
-  );
+  bcs.registerType(LegacyBCS.HEX, (writer, data, _, __) {
+    return writer.writeVec(fromHEX(data), (writer, el, _, __) => writer.write8(el));
+  }, (reader, _, __) {
+    final bytes = reader.readVec((reader, _, __) => reader.read8());
+    return toHEX(Uint8List.fromList(bytes.cast<int>()));
+  });
 
-  bcs.registerType(
-    LegacyBCS.U64,
-    (writer, data, _, __) {
-      return writer.write64(BigInt.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read64().toString();
-    }
-  );
+  bcs.registerType(LegacyBCS.BASE58, (writer, data, _, __) {
+    return writer.writeVec(fromB58(data), (writer, el, _, __) => writer.write8(el));
+  }, (reader, _, __) {
+    final bytes = reader.readVec((reader, _, __) => reader.read8());
+    return toB58(Uint8List.fromList(bytes.cast<int>()));
+  });
 
-  bcs.registerType(
-    LegacyBCS.U128,
-    (writer, data, _, __) {
-      return writer.write128(BigInt.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read128().toString();
-    }
-  );
-
-  bcs.registerType(
-    LegacyBCS.U256,
-    (writer, data, _, __) {
-      return writer.write256(BigInt.parse(data.toString()));
-    },
-    (reader, _, __) {
-      return reader.read256().toString();
-    }
-  );
-
-  bcs.registerType(
-    LegacyBCS.BOOL,
-    (writer, data, _, __) {
-      return writer.write8(data == true ? 1 : 0);
-    },
-    (reader, _, __) {
-      return reader.read8().toString() == "1";
-    }
-  );
-
-  bcs.registerType(
-    LegacyBCS.STRING,
-    (writer, data, _, __) =>
-      writer.writeVec(data.split(""), (writer, el, a, b) {
-        writer.write8(utf8.encode(el)[0]);
-      }),
-    (reader, _, __) {
-      final data = reader
-        .readVec((reader, a, b) => reader.read8())
-        .map<int>((item) => item.toInt()).toList();
-      return utf8.decode(data);
-    },
-    (_str) => true
-  );
-
-  bcs.registerType(
-    LegacyBCS.HEX,
-    (writer, data, _, __) {
-      return writer.writeVec(fromHEX(data), (writer, el, _, __) =>
-        writer.write8(el)
-      );
-    },
-    (reader, _, __) {
-      final bytes = reader.readVec((reader, _, __) => reader.read8());
-      return toHEX(Uint8List.fromList(bytes.cast<int>()));
-    }
-  );
-
-  bcs.registerType(
-    LegacyBCS.BASE58,
-    (writer, data, _, __) {
-      return writer.writeVec(fromB58(data), (writer, el, _, __) =>
-        writer.write8(el)
-      );
-    },
-    (reader, _, __) {
-      final bytes = reader.readVec((reader, _, __) => reader.read8());
-      return toB58(Uint8List.fromList(bytes.cast<int>()));
-    }
-  );
-
-  bcs.registerType(
-    LegacyBCS.BASE64,
-    (writer, data, _, __) {
-      return writer.writeVec(fromB64(data), (writer, el, _, __) =>
-        writer.write8(el)
-      );
-    },
-    (reader, _, __) {
-      final bytes = reader.readVec((reader, _, __) => reader.read8());
-      return toB64(Uint8List.fromList(bytes.cast<int>()));
-    }
-  );
+  bcs.registerType(LegacyBCS.BASE64, (writer, data, _, __) {
+    return writer.writeVec(fromB64(data), (writer, el, _, __) => writer.write8(el));
+  }, (reader, _, __) {
+    final bytes = reader.readVec((reader, _, __) => reader.read8());
+    return toB64(Uint8List.fromList(bytes.cast<int>()));
+  });
 }
 
 BcsConfig getRustConfig() {
   return BcsConfig(
-    vectorType: "Vec",
-    addressLength: SUI_ADDRESS_LENGTH,
-    genericSeparators: ("<", ">"),
-    addressEncoding: Encoding.hex
-  );
+      vectorType: "Vec",
+      addressLength: SUI_ADDRESS_LENGTH,
+      genericSeparators: ("<", ">"),
+      addressEncoding: Encoding.hex);
 }
 
 BcsConfig getSuiMoveConfig() {
   return BcsConfig(
-    vectorType: LegacyBCS.VECTOR,
-    fixedArrayType: LegacyBCS.FixedArray,
-    addressLength: SUI_ADDRESS_LENGTH,
-    genericSeparators: ("<", ">"),
-    addressEncoding: Encoding.hex
-  );
+      vectorType: LegacyBCS.VECTOR,
+      fixedArrayType: LegacyBCS.FixedArray,
+      addressLength: SUI_ADDRESS_LENGTH,
+      genericSeparators: ("<", ">"),
+      addressEncoding: Encoding.hex);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -6,6 +6,6 @@ repository: https://github.com/mofalabs/bcs
 environment:
   sdk: ">=3.0.3 <4.0.0"
 
-
 dev_dependencies:
   test: ^1.26.3
+  lints: ^5.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,14 +5,7 @@ repository: https://github.com/mofalabs/bcs
 
 environment:
   sdk: ">=3.0.3 <4.0.0"
-  flutter: ">=1.17.0"
-
-dependencies:
-  flutter:
-    sdk: flutter
 
 
 dev_dependencies:
-  flutter_test:
-    sdk: flutter
-  flutter_lints: ^1.0.0
+  test: ^1.26.3

--- a/test/alias_test.dart
+++ b/test/alias_test.dart
@@ -1,11 +1,7 @@
-
 import 'package:bcs/bcs.dart';
-import 'package:bcs/legacy_bcs.dart';
-import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-  
   dynamic serde(LegacyBCS bcs, dynamic type, dynamic data) {
     final ser = bcs.ser(type, data).hex();
     final de = bcs.de(type, ser, Encoding.hex);
@@ -23,10 +19,10 @@ void main() {
 
     test("should support recursive definitions in structs", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
-      const value = { "name": "Billy" };
+      const value = {"name": "Billy"};
 
       bcs.registerAlias("UserName", LegacyBCS.STRING);
-      expect(serde(bcs, { "name": "UserName" }, value), value);
+      expect(serde(bcs, {"name": "UserName"}, value), value);
     });
 
     test("should spot recursive definitions", () {
@@ -46,5 +42,4 @@ void main() {
       expect(error is ArgumentError, true);
     });
   });
-
 }

--- a/test/bcs_test.dart
+++ b/test/bcs_test.dart
@@ -1,9 +1,8 @@
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 import 'package:bcs/bcs.dart';
 
 void main() {
-
   group('BCS: Primitives', () {
     test('should support growing size', () {
       final Coin = Bcs.struct('Coin', {
@@ -38,8 +37,8 @@ void main() {
         "is_locked": false,
       };
 
-      expect(() => Coin.serialize(expected, options: BcsWriterOptions(size: 1, maxSize: 1)), throwsArgumentError);
+      expect(() => Coin.serialize(expected, options: BcsWriterOptions(size: 1, maxSize: 1)),
+          throwsArgumentError);
     });
   });
-
 }

--- a/test/builder_test.dart
+++ b/test/builder_test.dart
@@ -5,37 +5,31 @@ import 'package:bcs/bcs_type.dart';
 import 'package:bcs/reader.dart';
 import 'package:bcs/utils.dart';
 import 'package:bcs/writer.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
-  void testType<T, Input>(
-    String name,
-    BcsType<T, Input> schema,
-    Input value,
-    String hex,
-    [T? expected]
-  ) {
+  void testType<T, Input>(String name, BcsType<T, Input> schema, Input value, String hex,
+      [T? expected]) {
     expected ??= value as T;
 
     test(name, () {
       final serialized = schema.serialize(value);
       final bytes = serialized.toBytes();
-      expect(toHEX(bytes),hex);
-      expect(serialized.toHex(),hex);
-      expect(serialized.toBase64(),toB64(bytes));
-      expect(serialized.toBase58(),toB58(bytes));
+      expect(toHEX(bytes), hex);
+      expect(serialized.toHex(), hex);
+      expect(serialized.toBase64(), toB64(bytes));
+      expect(serialized.toBase58(), toB58(bytes));
 
       final deserialized = schema.parse(bytes);
-      expect(deserialized,expected);
+      expect(deserialized, expected);
 
       final writer = BcsWriter(size: bytes.length);
       schema.write(value, writer);
-      expect(toHEX(writer.toBytes()),hex);
+      expect(toHEX(writer.toBytes()), hex);
 
       final reader = BcsReader(bytes);
 
-      expect(schema.read(reader),expected);
+      expect(schema.read(reader), expected);
     });
   }
 
@@ -78,12 +72,18 @@ void main() {
       testType('u64 256', Bcs.u64(), BigInt.from(256), '0001000000000000', BigInt.from(256));
       testType('u64 65535', Bcs.u64(), BigInt.from(65535), 'ffff000000000000', BigInt.from(65535));
       testType('u64 65536', Bcs.u64(), BigInt.from(65536), '0000010000000000', BigInt.from(65536));
-      testType('u64 16777215', Bcs.u64(), BigInt.from(16777215), 'ffffff0000000000', BigInt.from(16777215));
-      testType('u64 16777216', Bcs.u64(), BigInt.from(16777216), '0000000100000000', BigInt.from(16777216));
-      testType('u64 4294967295', Bcs.u64(),  BigInt.from(4294967295), 'ffffffff00000000', BigInt.from(4294967295));
-      testType('u64 4294967296', Bcs.u64(), BigInt.from(4294967296), '0000000001000000', BigInt.from(4294967296));
-      testType('u64 1099511627775', Bcs.u64(), BigInt.parse('1099511627775'), 'ffffffffff000000', BigInt.parse('1099511627775'));
-      testType('u64 1099511627776', Bcs.u64(), BigInt.parse('1099511627776'), '0000000000010000', BigInt.parse('1099511627776'));
+      testType('u64 16777215', Bcs.u64(), BigInt.from(16777215), 'ffffff0000000000',
+          BigInt.from(16777215));
+      testType('u64 16777216', Bcs.u64(), BigInt.from(16777216), '0000000100000000',
+          BigInt.from(16777216));
+      testType('u64 4294967295', Bcs.u64(), BigInt.from(4294967295), 'ffffffff00000000',
+          BigInt.from(4294967295));
+      testType('u64 4294967296', Bcs.u64(), BigInt.from(4294967296), '0000000001000000',
+          BigInt.from(4294967296));
+      testType('u64 1099511627775', Bcs.u64(), BigInt.parse('1099511627775'), 'ffffffffff000000',
+          BigInt.parse('1099511627775'));
+      testType('u64 1099511627776', Bcs.u64(), BigInt.parse('1099511627776'), '0000000000010000',
+          BigInt.parse('1099511627776'));
       testType(
         'u64 281474976710655',
         Bcs.u64(),
@@ -119,9 +119,12 @@ void main() {
         'ffffffffffffffff',
         BigInt.parse('18446744073709551615'),
       );
-      testType('u128 0', Bcs.u128(), BigInt.parse('0'), '00000000000000000000000000000000', BigInt.parse('0'));
-      testType('u128 1', Bcs.u128(), BigInt.parse('1'), '01000000000000000000000000000000', BigInt.parse('1'));
-      testType('u128 255', Bcs.u128(), BigInt.parse('255'), 'ff000000000000000000000000000000', BigInt.parse('255'));
+      testType('u128 0', Bcs.u128(), BigInt.parse('0'), '00000000000000000000000000000000',
+          BigInt.parse('0'));
+      testType('u128 1', Bcs.u128(), BigInt.parse('1'), '01000000000000000000000000000000',
+          BigInt.parse('1'));
+      testType('u128 255', Bcs.u128(), BigInt.parse('255'), 'ff000000000000000000000000000000',
+          BigInt.parse('255'));
       testType(
         'u128 18446744073709551615',
         Bcs.u128(),
@@ -250,7 +253,6 @@ void main() {
             "bytes": Uint8List.fromList([0xc0, 0xde]),
             "label": 'a',
           },
-
           "name": 'b',
         },
         '0102c0de01610162',
@@ -272,13 +274,19 @@ void main() {
         "Variant2": Bcs.string(),
       });
 
-      testType('Enum::Variant0(1)', E, { "Variant0": 1 }, '000100', { "\$kind": 'Variant0', "Variant0": 1 });
-      testType('Enum::Variant1(1)', E, { "Variant1": 1 }, '0101', { "\$kind": 'Variant1', "Variant1": 1 });
-      testType('Enum::Variant2("hello")', E, { "Variant2": 'hello' }, '020568656c6c6f', {
-        "\$kind": 'Variant2',
-        "Variant2": 'hello',
-      });
+      testType(
+          'Enum::Variant0(1)', E, {"Variant0": 1}, '000100', {"\$kind": 'Variant0', "Variant0": 1});
+      testType(
+          'Enum::Variant1(1)', E, {"Variant1": 1}, '0101', {"\$kind": 'Variant1', "Variant1": 1});
+      testType(
+          'Enum::Variant2("hello")',
+          E,
+          {"Variant2": 'hello'},
+          '020568656c6c6f',
+          {
+            "\$kind": 'Variant2',
+            "Variant2": 'hello',
+          });
     });
   });
-
 }

--- a/test/config_test.dart
+++ b/test/config_test.dart
@@ -1,63 +1,61 @@
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   dynamic serde(LegacyBCS bcs, type, data) {
     final ser = bcs.ser(type, data).hex();
     final de = bcs.de(type, ser, Encoding.hex);
     return de;
   }
 
-    group("BCS: Config", () {
-        test("should work wtesth Rust config", () {
-            final bcs = LegacyBCS(getRustConfig());
-            final value = ["beep", "boop", "beep"];
-            expect(serde(bcs, "Vec<string>", value),value);
-        });
-
-        test("should work wtesth Sui Move config", () {
-            final bcs = LegacyBCS(getSuiMoveConfig());
-            final value = ["beep", "boop", "beep"];
-            expect(serde(bcs, "vector<string>", value),value);
-        });
-
-        test("should fork config", () {
-            final bcs_v1 = LegacyBCS(getSuiMoveConfig());
-            bcs_v1.registerStructType("User", { "name": "string" });
-
-            final bcs_v2 = LegacyBCS.fromBCS(bcs_v1);
-            bcs_v2.registerStructType("Worker", { "user": "User", "experience": "u64" });
-
-            expect(bcs_v1.hasType("Worker"), false);
-            expect(bcs_v2.hasType("Worker"), true);
-        });
-
-        test("should work wtesth custom config", () {
-            final bcs = LegacyBCS(BcsConfig(
-              genericSeparators: ("[", "]"),
-              addressLength: 1,
-              addressEncoding: Encoding.hex,
-              vectorType: "array",
-              types: BcsConfigTypes(
-                  structs: {
-                    "StesteConfig": { "tags": "array[Name]" },
-                  },
-                  enums: {
-                    "Option[T]": { "none": null, "some": "T" },
-                  },
-                  aliases: {
-                      "Name": 'string'
-                  })
-            ));
-
-            final value_1 = { "tags": ["beep", "boop", "beep"] };
-            expect(serde(bcs, "StesteConfig", value_1), value_1);
-
-            final value_2 = { "some": ["what", "do", "we", "test"] };
-            expect(serde(bcs, "Option[array[string]]", value_2), value_2);
-        });
+  group("BCS: Config", () {
+    test("should work wtesth Rust config", () {
+      final bcs = LegacyBCS(getRustConfig());
+      final value = ["beep", "boop", "beep"];
+      expect(serde(bcs, "Vec<string>", value), value);
     });
+
+    test("should work wtesth Sui Move config", () {
+      final bcs = LegacyBCS(getSuiMoveConfig());
+      final value = ["beep", "boop", "beep"];
+      expect(serde(bcs, "vector<string>", value), value);
+    });
+
+    test("should fork config", () {
+      final bcs_v1 = LegacyBCS(getSuiMoveConfig());
+      bcs_v1.registerStructType("User", {"name": "string"});
+
+      final bcs_v2 = LegacyBCS.fromBCS(bcs_v1);
+      bcs_v2.registerStructType("Worker", {"user": "User", "experience": "u64"});
+
+      expect(bcs_v1.hasType("Worker"), false);
+      expect(bcs_v2.hasType("Worker"), true);
+    });
+
+    test("should work wtesth custom config", () {
+      final bcs = LegacyBCS(BcsConfig(
+          genericSeparators: ("[", "]"),
+          addressLength: 1,
+          addressEncoding: Encoding.hex,
+          vectorType: "array",
+          types: BcsConfigTypes(structs: {
+            "StesteConfig": {"tags": "array[Name]"},
+          }, enums: {
+            "Option[T]": {"none": null, "some": "T"},
+          }, aliases: {
+            "Name": 'string'
+          })));
+
+      final value_1 = {
+        "tags": ["beep", "boop", "beep"]
+      };
+      expect(serde(bcs, "StesteConfig", value_1), value_1);
+
+      final value_2 = {
+        "some": ["what", "do", "we", "test"]
+      };
+      expect(serde(bcs, "Option[array[string]]", value_2), value_2);
+    });
+  });
 }

--- a/test/encoding_test.dart
+++ b/test/encoding_test.dart
@@ -1,13 +1,10 @@
-
 import 'dart:typed_data';
 
 import 'package:bcs/index.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   group('BCS: Encodings', () {
     test('should de/ser hex, base58 and base64', () {
       expect(Bcs.u8().parse(fromB64('AA==')), 0);
@@ -32,14 +29,44 @@ void main() {
       expect(fromHEX('011'), Uint8List.fromList([0, 17]));
       expect(fromHEX('0011'), Uint8List.fromList([0, 17]));
       expect(fromHEX('0x0011'), Uint8List.fromList([0, 17]));
-      expect(fromHEX(addressLeading0), 
+      expect(
+        fromHEX(addressLeading0),
         Uint8List.fromList([
-          10, 116, 41, 215, 163, 86, 221, 152, 246, 136, 241, 26, 51, 10, 50, 224, 163, 204, 25, 8,
-          115, 74, 140, 90, 90, 249, 143, 52, 236, 147, 223, 12,
+          10,
+          116,
+          41,
+          215,
+          163,
+          86,
+          221,
+          152,
+          246,
+          136,
+          241,
+          26,
+          51,
+          10,
+          50,
+          224,
+          163,
+          204,
+          25,
+          8,
+          115,
+          74,
+          140,
+          90,
+          90,
+          249,
+          143,
+          52,
+          236,
+          147,
+          223,
+          12,
         ]),
       );
       expect(toHEX(fromHEX(addressLeading0)), "0$addressLeading0");
     });
   });
-  
 }

--- a/test/generics_test.dart
+++ b/test/generics_test.dart
@@ -1,10 +1,8 @@
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   group("BCS: Generics", () {
     test("should handle generics", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
@@ -14,7 +12,7 @@ void main() {
         "some": "T",
       });
 
-      expect(bcs.de("base::Option<u8>", "00", Encoding.hex),{ "none": true });
+      expect(bcs.de("base::Option<u8>", "00", Encoding.hex), {"none": true});
     });
 
     test("should handle nested generics", () {
@@ -30,22 +28,21 @@ void main() {
         "data": "base::Option<S>",
       });
 
-      expect(bcs.de("base::Container<bool, u8>", "0000", Encoding.hex),{
+      expect(bcs.de("base::Container<bool, u8>", "0000", Encoding.hex), {
         "tag": false,
-        "data": { "none": true },
+        "data": {"none": true},
       });
 
       bcs.registerStructType("base::Wrapper", {
         "wrapped": "base::Container<bool, u8>",
       });
 
-      expect(bcs.de("base::Wrapper", "0000", Encoding.hex),{
+      expect(bcs.de("base::Wrapper", "0000", Encoding.hex), {
         "wrapped": {
           "tag": false,
-          "data": { "none": true },
+          "data": {"none": true},
         },
       });
     });
   });
-
 }

--- a/test/inline_definition_test.dart
+++ b/test/inline_definition_test.dart
@@ -1,10 +1,8 @@
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   dynamic serde(LegacyBCS bcs, type, data) {
     final ser = bcs.ser(type, data).hex();
     final de = bcs.de(type, ser, Encoding.hex);
@@ -13,7 +11,7 @@ void main() {
 
   group("BCS: Inline struct defintestions", () {
     test("should de/serialize inline defintestion", () {
-      final bcs =  LegacyBCS(getSuiMoveConfig());
+      final bcs = LegacyBCS(getSuiMoveConfig());
       const value = {
         "t1": "Adam",
         "t2": "1000",
@@ -21,37 +19,39 @@ void main() {
       };
 
       expect(
-        serde(
-          bcs,
-          {
-            "t1": "string",
-            "t2": "u64",
-            "t3": "vector<hex-string>",
-          },
-          value
-        )
-     ,value);
+          serde(
+              bcs,
+              {
+                "t1": "string",
+                "t2": "u64",
+                "t3": "vector<hex-string>",
+              },
+              value),
+          value);
     });
 
     test("should not contain a trace of the temp struct", () {
-      final bcs =  LegacyBCS(getSuiMoveConfig());
-      final _sr = bcs
-        .ser({ "name": "string", "age": "u8" }, { "name": "Charlie", "age": 10 })
-        .hex();
+      final bcs = LegacyBCS(getSuiMoveConfig());
+      final _sr = bcs.ser({"name": "string", "age": "u8"}, {"name": "Charlie", "age": 10}).hex();
 
       expect(bcs.hasType("temp-struct"), false);
     });
 
     test("should avoid duplicate key", () {
-      final bcs =  LegacyBCS(getSuiMoveConfig());
+      final bcs = LegacyBCS(getSuiMoveConfig());
 
-      bcs.registerStructType("temp-struct", { "a0": "u8" });
+      bcs.registerStructType("temp-struct", {"a0": "u8"});
 
-      final sr = serde(bcs, { "b0": "temp-struct" }, { "b0": { "a0": 0 } });
+      final sr = serde(bcs, {
+        "b0": "temp-struct"
+      }, {
+        "b0": {"a0": 0}
+      });
 
       expect(bcs.hasType("temp-struct"), true);
-      expect(sr, { "b0": { "a0": 0 } });
+      expect(sr, {
+        "b0": {"a0": 0}
+      });
     });
   });
-
 }

--- a/test/nested_object_test.dart
+++ b/test/nested_object_test.dart
@@ -1,11 +1,8 @@
-
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   dynamic serde(LegacyBCS bcs, dynamic type, dynamic data) {
     final ser = bcs.ser(type, data).hex();
     final de = bcs.de(type, ser, Encoding.hex);
@@ -15,7 +12,9 @@ void main() {
   group("BCS: Nested temp object", () {
     test("should support object as a type", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
-      const value = { "name": { "boop": "beep", "beep": "100" } };
+      const value = {
+        "name": {"boop": "beep", "beep": "100"}
+      };
 
       bcs.registerStructType("Beep", {
         "name": {
@@ -81,5 +80,4 @@ void main() {
       expect(serde(bcs, "Option", value), value);
     });
   });
-
 }

--- a/test/readme_test.dart
+++ b/test/readme_test.dart
@@ -1,8 +1,6 @@
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
   group("BCS: README Examples", () {
@@ -21,42 +19,39 @@ void main() {
       });
 
       // deserialization: BCS bytes into Coin
-      final bytes = bcs
-        .ser("Coin", {
-          "id": "0000000000000000000000000000000000000000000000000000000000000001",
-          "value": BigInt.from(1000000),
-        })
-        .toBytes();
-    
+      final bytes = bcs.ser("Coin", {
+        "id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "value": BigInt.from(1000000),
+      }).toBytes();
+
       final coin = bcs.de("Coin", bytes);
 
       // serialization: Object into bytes
-      final data = bcs.ser("Option<Coin>", { "some": coin }).hex();
-      debugPrint(data);
+      final data = bcs.ser("Option<Coin>", {"some": coin}).hex();
+      print(data);
     });
 
     test("Example: All options used", () {
       final bcs = LegacyBCS(BcsConfig(
-        vectorType: "vector<T>",
-        addressLength: SUI_ADDRESS_LENGTH,
-        addressEncoding: Encoding.hex,
-        genericSeparators: ("<", ">"),
-        types: BcsConfigTypes(
-          // define schema in the intestializer
-          structs: {
-            "User": {
-              "name": LegacyBCS.STRING,
-              "age": LegacyBCS.U8,
+          vectorType: "vector<T>",
+          addressLength: SUI_ADDRESS_LENGTH,
+          addressEncoding: Encoding.hex,
+          genericSeparators: ("<", ">"),
+          types: BcsConfigTypes(
+            // define schema in the intestializer
+            structs: {
+              "User": {
+                "name": LegacyBCS.STRING,
+                "age": LegacyBCS.U8,
+              },
             },
-          },
-          enums: {},
-          aliases: { "hex": LegacyBCS.HEX },
-        ),
-        withPrimitives: true
-      ));
+            enums: {},
+            aliases: {"hex": LegacyBCS.HEX},
+          ),
+          withPrimitives: true));
 
-      final bytes = bcs.ser("User", { "name": "Adam", "age": "30" }).base64();
-      debugPrint(bytes);
+      final bytes = bcs.ser("User", {"name": "Adam", "age": "30"}).base64();
+      print(bytes);
     });
 
     test("intestialization", () {
@@ -91,26 +86,21 @@ void main() {
 
       // Other types
       final _bool = bcs.ser(LegacyBCS.BOOL, true).hex();
-      final _addr = bcs
-        .ser(LegacyBCS.ADDRESS, "0000000000000000000000000000000000000001")
-        .toBytes();
+      final _addr =
+          bcs.ser(LegacyBCS.ADDRESS, "0000000000000000000000000000000000000001").toBytes();
       final _str = bcs.ser(LegacyBCS.STRING, "this is an ascii string").toBytes();
 
       // Vectors (vector<T>)
       final _u8_vec = bcs.ser("vector<u8>", [1, 2, 3, 4, 5, 6, 7]).toBytes();
       final _bool_vec = bcs.ser("vector<bool>", [true, true, false]).toBytes();
-      final _str_vec = bcs
-        .ser("vector<bool>", ["string1", "string2", "string3"])
-        .toBytes();
+      final _str_vec = bcs.ser("vector<bool>", ["string1", "string2", "string3"]).toBytes();
 
       // Even vector of vector (...of vector) is an option
-      final _matrix = bcs
-        .ser("vector<vector<u8>>", [
-          [0, 0, 0],
-          [1, 1, 1],
-          [2, 2, 2],
-        ])
-        .toBytes();
+      final _matrix = bcs.ser("vector<vector<u8>>", [
+        [0, 0, 0],
+        [1, 1, 1],
+        [2, 2, 2],
+      ]).toBytes();
     });
 
     test("Example: Ser/de and Encoding", () {
@@ -170,14 +160,12 @@ void main() {
 
       // value passed into ser function has to have the same
       // structure as the defintestion
-      final _bytes = bcs
-        .ser("Coin", {
-          "id": "0x0000000000000000000000000000000000000000000000000000000000000005",
-          "balance": {
-            "value": BigInt.from(100000000),
-          },
-        })
-        .toBytes();
+      final _bytes = bcs.ser("Coin", {
+        "id": "0x0000000000000000000000000000000000000000000000000000000000000005",
+        "balance": {
+          "value": BigInt.from(100000000),
+        },
+      }).toBytes();
     });
 
     test("Example: Generics", () {
@@ -186,34 +174,47 @@ void main() {
       // Container -> the name of the type
       // T -> type parameter which has to be passed in `ser()` or `de()` methods
       // If you're not familiar wtesth generics, treat them as type Templates
-      bcs.registerStructType(["Container", "T"], {
+      bcs.registerStructType([
+        "Container",
+        "T"
+      ], {
         "contents": "T",
       });
 
       // When serializing, we have to pass the type to use for `T`
-      bcs
-        .ser(["Container", LegacyBCS.U8], {
-          "contents": 100,
-        })
-        .hex();
+      bcs.ser([
+        "Container",
+        LegacyBCS.U8
+      ], {
+        "contents": 100,
+      }).hex();
 
       // Reusing the same Container type wtesth different contents.
       // Mind that generics need to be passed as Array after the main type.
-      bcs
-        .ser(["Container", ["vector", LegacyBCS.BOOL]], {
-          "contents": [true, false, true],
-        })
-        .hex();
+      bcs.ser([
+        "Container",
+        ["vector", LegacyBCS.BOOL]
+      ], {
+        "contents": [true, false, true],
+      }).hex();
 
       // Using multiple generics - you can use any string for convenience and
       // readabiltesty. See how we also use array notation for a field defintestion.
-      bcs.registerStructType(["VecMap", "Key", "Val"], {
+      bcs.registerStructType([
+        "VecMap",
+        "Key",
+        "Val"
+      ], {
         "keys": ["vector", "Key"],
         "values": ["vector", "Val"],
       });
 
       // To serialize VecMap, we can use:
-      bcs.ser(["VecMap", LegacyBCS.STRING, LegacyBCS.STRING], {
+      bcs.ser([
+        "VecMap",
+        LegacyBCS.STRING,
+        LegacyBCS.STRING
+      ], {
         "keys": ["key1", "key2", "key3"],
         "values": ["value1", "value2", "value3"],
       });
@@ -265,12 +266,10 @@ void main() {
       };
 
       // Instead of defining a type we pass struct schema as the first argument
-      final coin_bytes = bcs
-        .ser({ "id": LegacyBCS.ADDRESS, "value": LegacyBCS.U64 }, coin)
-        .toBytes();
+      final coin_bytes = bcs.ser({"id": LegacyBCS.ADDRESS, "value": LegacyBCS.U64}, coin).toBytes();
 
       // Same wtesth deserialization
-      final coin_restored = bcs.de({ "id": LegacyBCS.ADDRESS, "value": LegacyBCS.U64 }, coin_bytes);
+      final coin_restored = bcs.de({"id": LegacyBCS.ADDRESS, "value": LegacyBCS.U64}, coin_bytes);
 
       expect(coin["id"], coin_restored["id"]);
       expect(coin["value"], BigInt.parse(coin_restored["value"]));

--- a/test/serde_test.dart
+++ b/test/serde_test.dart
@@ -1,10 +1,8 @@
-
 import 'package:bcs/legacy_bcs.dart';
 import 'package:bcs/utils.dart';
-import 'package:flutter_test/flutter_test.dart';
+import 'package:test/test.dart';
 
 void main() {
-
   dynamic serde(LegacyBCS bcs, type, data) {
     final ser = bcs.ser(type, data).hex();
     final de = bcs.de(type, ser, Encoding.hex);
@@ -12,57 +10,46 @@ void main() {
   }
 
   group("BCS: Serde", () {
-
     test("should serialize primtestives in both directions", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
 
       expect(serde(bcs, "u8", "0"), 0);
-      expect(serde(bcs, "u8", "200"),200);
-      expect(serde(bcs, "u8", "255"),255);
+      expect(serde(bcs, "u8", "200"), 200);
+      expect(serde(bcs, "u8", "255"), 255);
 
-      expect(serde(bcs, "u16", "10000"),10000);
-      expect(serde(bcs, "u32", "10000"),10000);
-      expect(serde(bcs, "u256", "10000"),"10000");
+      expect(serde(bcs, "u16", "10000"), 10000);
+      expect(serde(bcs, "u32", "10000"), 10000);
+      expect(serde(bcs, "u256", "10000"), "10000");
 
       expect(bcs.ser("u256", "100000").hex(),
-        "a086010000000000000000000000000000000000000000000000000000000000"
-      );
+          "a086010000000000000000000000000000000000000000000000000000000000");
 
-      expect(serde(bcs, "u64", "1000"),"1000");
-      expect(serde(bcs, "u128", "1000"),"1000");
-      expect(serde(bcs, "u256", "1000"),"1000");
+      expect(serde(bcs, "u64", "1000"), "1000");
+      expect(serde(bcs, "u128", "1000"), "1000");
+      expect(serde(bcs, "u256", "1000"), "1000");
 
-      expect(serde(bcs, "bool", true),true);
-      expect(serde(bcs, "bool", false),false);
+      expect(serde(bcs, "bool", true), true);
+      expect(serde(bcs, "bool", false), false);
 
       expect(
-        serde(
-          bcs,
-          "address",
-          "0x000000000000000000000000e3edac2c684ddbba5ad1a2b90fb361100b2094af"
-        )
-      ,
-        "000000000000000000000000e3edac2c684ddbba5ad1a2b90fb361100b2094af"
-      );
+          serde(
+              bcs, "address", "0x000000000000000000000000e3edac2c684ddbba5ad1a2b90fb361100b2094af"),
+          "000000000000000000000000e3edac2c684ddbba5ad1a2b90fb361100b2094af");
     });
 
     test("should serde structs", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
 
       bcs.registerAddressType("address", SUI_ADDRESS_LENGTH, Encoding.hex);
-      bcs.registerStructType("Beep", { "id": "address", "value": "u64" });
+      bcs.registerStructType("Beep", {"id": "address", "value": "u64"});
 
-      final bytes = bcs
-        .ser("Beep", {
-          "id": "0x00000000000000000000000045aacd9ed90a5a8e211502ac3fa898a3819f23b2",
-          "value": 10000000,
-        })
-        .toBytes();
+      final bytes = bcs.ser("Beep", {
+        "id": "0x00000000000000000000000045aacd9ed90a5a8e211502ac3fa898a3819f23b2",
+        "value": 10000000,
+      }).toBytes();
       final struct = bcs.de("Beep", bytes);
 
-      expect(struct["id"],
-        "00000000000000000000000045aacd9ed90a5a8e211502ac3fa898a3819f23b2"
-      );
+      expect(struct["id"], "00000000000000000000000045aacd9ed90a5a8e211502ac3fa898a3819f23b2");
       expect(struct["value"], "10000000");
     });
 
@@ -76,11 +63,9 @@ void main() {
 
       const addr = "bb967ddbebfee8c40d8fdd2c24cb02452834cd3a7061d18564448f900eb9e66d";
 
-      expect(addr,
-        bcs.de("Enum", bcs.ser("Enum", { "with_value": addr }).toBytes())["with_value"]
-      );
+      expect(addr, bcs.de("Enum", bcs.ser("Enum", {"with_value": addr}).toBytes())["with_value"]);
 
-      Map<String, dynamic> tmp = bcs.de("Enum", bcs.ser("Enum", { "no_value": null }).toBytes());
+      Map<String, dynamic> tmp = bcs.de("Enum", bcs.ser("Enum", {"no_value": null}).toBytes());
       expect(tmp.containsKey("no_value"), true);
     });
 
@@ -89,23 +74,17 @@ void main() {
 
       {
         final value = ["0", "255", "100"];
-        expect(
-          serde(bcs, "vector<u8>", value).map((e) => e.toString())
-        , value);
+        expect(serde(bcs, "vector<u8>", value).map((e) => e.toString()), value);
       }
 
       {
         const value = ["100000", "555555555", "1123123", "0", "1214124124214"];
-        expect(
-          serde(bcs, "vector<u64>", value).map((e) => e.toString())
-        , value);
+        expect(serde(bcs, "vector<u64>", value).map((e) => e.toString()), value);
       }
 
       {
         const value = ["100000", "555555555", "1123123", "0", "1214124124214"];
-        expect(
-          serde(bcs, "vector<u128>", value).map((e) => e.toString())
-        , value);
+        expect(serde(bcs, "vector<u128>", value).map((e) => e.toString()), value);
       }
 
       {
@@ -139,9 +118,9 @@ void main() {
     test("should structs and nested enums", () {
       final bcs = LegacyBCS(getSuiMoveConfig());
 
-      bcs.registerStructType("User", { "age": "u64", "name": "string" });
-      bcs.registerStructType("Coin<T>", { "balance": "Balance<T>" });
-      bcs.registerStructType("Balance<T>", { "value": "u64" });
+      bcs.registerStructType("User", {"age": "u64", "name": "string"});
+      bcs.registerStructType("Coin<T>", {"balance": "Balance<T>"});
+      bcs.registerStructType("Balance<T>", {"value": "u64"});
 
       bcs.registerStructType("Container<T>", {
         "owner": "address",
@@ -150,17 +129,18 @@ void main() {
       });
 
       {
-        final value = { "age": "30", "name": "Bob" };
+        final value = {"age": "30", "name": "Bob"};
         expect(serde(bcs, "User", value)["age"], value["age"]);
         expect(serde(bcs, "User", value)["name"], value["name"]);
       }
 
       {
         Map<String, dynamic> value = {
-          "owner":
-            "0000000000000000000000000000000000000000000000000000000000000001",
+          "owner": "0000000000000000000000000000000000000000000000000000000000000001",
           "is_active": true,
-          "testem": { "balance": { "value": "10000" } },
+          "testem": {
+            "balance": {"value": "10000"}
+          },
         };
 
         // Deep Nested Generic!
@@ -168,9 +148,7 @@ void main() {
 
         expect(result["owner"], value["owner"]);
         expect(result["is_active"], value["is_active"]);
-        expect(result["testem"]["balance"]["value"],
-          value["testem"]["balance"]["value"]
-        );
+        expect(result["testem"]["balance"]["value"], value["testem"]["balance"]["value"]);
       }
     });
 
@@ -185,8 +163,7 @@ void main() {
       bcs.registerAlias("ObjectDigest", LegacyBCS.STRING);
 
       const value = {
-        "objectId":
-          "5443700000000000000000000000000000000000000000000000000000000000",
+        "objectId": "5443700000000000000000000000000000000000000000000000000000000000",
         "version": "9180",
         "digest": "hahahahahaha",
       };


### PR DESCRIPTION
Replaced flutter_test with the standard test package to remove Flutter-specific dependencies.

This makes the BCS library more platform-agnostic and ensures it can be used independently of Flutter, such as in pure Dart environments @0xmove 